### PR TITLE
bug fix for 1.9; lamdas with arguments are whitespace sensitive

### DIFF
--- a/lib/sharepoint-object.rb
+++ b/lib/sharepoint-object.rb
@@ -30,7 +30,7 @@ module Sharepoint
         method_params[:http_method]    ||= :post
         method_params[:endpoint]       ||= name.to_s.camelize
         method_params[:default_params] ||= Hash.new
-        define_method name, -> (params = Hash.new) do
+        define_method name, ->(params = Hash.new) do
           action = "#{__metadata['uri']}/#{method_params[:endpoint]}"
           body   = nil
           # Set default parameters


### PR DESCRIPTION
Hi. This gem works beautifully on ruby 2+ but I kept on getting syntax errors on 1.9. Getting rid of white space makes it backward compatible.

I was trying it on 1.9.3-p448.