### PR TITLE
fix find_items not working when make_item_filter returns a hash

### DIFF
--- a/lib/sharepoint-lists.rb
+++ b/lib/sharepoint-lists.rb
@@ -160,6 +160,7 @@ module Sharepoint
         url += "$#{key}=#{URI::encode value.to_s}"
         has_options = true
       end
+      url
     end
   end
 


### PR DESCRIPTION
Hello, thank you for this excellent gem. 

I was not able not able to get the List#find_items method to work. Changing make_item_filter to return a string seemed to fix the issue. To my recollection Curl::Easy.send was receiving a url string as an argument but the string query was formatted more like a ruby hash than the format needed by SharePoint. The make_item_filter builds the query string appropriately but needs to be returned in place of the options hash.

Thank you again. Please let me know if I have made any incorrect assumptions.