### PR TITLE
Fix for `constant ::Data is deprecated`` warning

### DIFF
--- a/lib/sharepoint-data.rb
+++ b/lib/sharepoint-data.rb
@@ -1,0 +1,5 @@
+module Sharepoint
+  module Data
+
+  end
+end

--- a/lib/sharepoint-types.rb
+++ b/lib/sharepoint-types.rb
@@ -28,6 +28,7 @@ require 'sharepoint-users'
 require 'sharepoint-lists'
 require 'sharepoint-files'
 require 'sharepoint-fields'
+require 'sharepoint-data'
 require 'date'
 
 module Sharepoint

--- a/sharepoint-ruby.gemspec
+++ b/sharepoint-ruby.gemspec
@@ -6,13 +6,7 @@ Gem::Specification.new do |s|
   s.description  = "Client for Sharepoint's REST API"
   s.authors      = ["Michael Martin Moro"]
   s.email        = 'michael@unetresgrossebite.com'
-  s.files        = ['lib/sharepoint-ruby.rb',   'lib/sharepoint-session.rb',
-                    'lib/sharepoint-object.rb', 'lib/sharepoint-types.rb', 'lib/sharepoint-properties.rb',
-                    'lib/sharepoint-users.rb',  'lib/sharepoint-lists.rb', 'lib/sharepoint-files.rb', 'lib/sharepoint-fields.rb',
-                    'lib/sharepoint-stringutils.rb',
-                    'lib/soap/authenticate.xml.erb',
-                    'lib/sharepoint-http-auth.rb',
-                    'lib/sharepoint-kerberos-auth.rb']
+  s.files        = Dir["lib/**/*", "MIT-LICENSE", "README.md"]
   s.homepage     = 'https://github.com/Plaristote/sharepoint-ruby'
   s.license      = 'BSD'
   s.require_path = 'lib'


### PR DESCRIPTION
Types of the form
  "SP.Data.Access_x0020_RequestsItem"
  "SP.Data.OData__x005f_catalogs_x002f_designItem"
  "SP.Data.Shared_x0020_DocumentsItem"
  "SP.Data.SiteAssetsItem"
  "SP.Data.UserInfoItem"
cause warnings like 
`lib/sharepoint-ruby.rb:125: warning: constant ::Data is deprecated`

This commit   
* Add a `Data` module to avoid deprecation errors caused 
* It can also be used as an entry point to add custom types