### PR TITLE
Add sites segment between server_url and site name in API calls

### DIFF
--- a/lib/sharepoint-ruby.rb
+++ b/lib/sharepoint-ruby.rb
@@ -16,7 +16,7 @@ module Sharepoint
     def initialize server_url, site_name
       @server_url  = server_url
       @name        = site_name
-      @url         = "#{@server_url}/#{@name}"
+      @url         = "#{@server_url}/sites/#{@name}"
       @session     = Session.new self
       @web_context = nil
       @protocol    = 'https'
@@ -61,7 +61,7 @@ module Sharepoint
         if method != :get
           curl.headers["Content-Type"]    = curl.headers["Accept"]
           curl.headers["X-RequestDigest"] = form_digest unless @getting_form_digest == true
-          curl.headers["Authorization"] = "Bearer " + form_digest unless @getting_form_digest == true          
+          curl.headers["Authorization"] = "Bearer " + form_digest unless @getting_form_digest == true
         end
         curl.verbose = @verbose
         @session.send :curl, curl unless not @session.methods.include? :curl

--- a/sharepoint-ruby.gemspec
+++ b/sharepoint-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name         = 'sharepoint-ruby'
-  s.version      = '0.1.2'
+  s.version      = '0.1.3'
   s.date         = '2021-01-03'
   s.summary      = 'sharepoint client'
   s.description  = "Client for Sharepoint's REST API"


### PR DESCRIPTION
It adds `sites` segment between server url and site name. Apparently sharepoint API has changed in the meantime since the last update of this gem, so it doesn't work without it (and returns 404 instead). 