### PR TITLE
Changes URI.encode by CGI.escape

### DIFF
--- a/lib/sharepoint-files.rb
+++ b/lib/sharepoint-files.rb
@@ -13,11 +13,11 @@ module Sharepoint
     method :recycle
 
     def file_from_name name
-      @site.query :get, "#{__metadata['uri']}/files/getbyurl('#{URI::encode(name.to_s)}')"
+      @site.query :get, "#{__metadata['uri']}/files/getbyurl('#{CGI.escape(name.to_s)}')"
     end
 
     def add_file name, content
-      uri = "#{__metadata['uri']}/files/add(overwrite=true,url='#{URI::encode(name.to_s)}')"
+      uri = "#{__metadata['uri']}/files/add(overwrite=true,url='#{CGI.escape(name.to_s)}')"
       @site.query :post, uri, content
     end
 

--- a/lib/sharepoint-lists.rb
+++ b/lib/sharepoint-lists.rb
@@ -157,7 +157,7 @@ module Sharepoint
       has_options = false
       options.each do |key,value|
         url += if has_options then '&' else '?' end
-        url += "$#{key}=#{URI::encode value.to_s}"
+        url += "$#{key}=#{CGI.escape value.to_s}"
         has_options = true
       end
       url


### PR DESCRIPTION
I upgraded my project from Ruby 2.4.5 to Ruby 3.0.2 and the solution for me was to replace:
`URI.encode` by `CGI.escape`

