### PR TITLE
Resolve whitespace encoding of filenames

### DIFF
--- a/lib/sharepoint-files.rb
+++ b/lib/sharepoint-files.rb
@@ -13,11 +13,11 @@ module Sharepoint
     method :recycle
 
     def file_from_name name
-      @site.query :get, "#{__metadata['uri']}/files/getbyurl('#{CGI.escape(name.to_s)}')"
+      @site.query :get, "#{__metadata['uri']}/files/getbyurl('#{URI::Parser.new.escape(name.to_s)}')"
     end
 
     def add_file name, content
-      uri = "#{__metadata['uri']}/files/add(overwrite=true,url='#{CGI.escape(name.to_s)}')"
+      uri = "#{__metadata['uri']}/files/add(overwrite=true,url='#{URI::Parser.new.escape(name.to_s)}')"
       @site.query :post, uri, content
     end
 


### PR DESCRIPTION
`CGI.escape` behaves slightly differently than the deprecated `URI.escape` method. In particular, it encodes whitespace characters with "+" instead of percent encoding them, which Sharepoint is expecting.

This pull request aligns Sharepoint Folder methods `file_from_name` and `add_file` with the solution used in https://github.com/Plaristote/sharepoint-ruby/pull/49, utilizing `URI::Parser.new.escape` to behave in the same manner as the old `URI.escape` method.

```
irb(main):008:0> name = "Test File With Spaces.csv"
=> "Test File With Spaces.csv"
irb(main):009:0> CGI.escape(name)
=> "Test+File+With+Spaces.csv"
irb(main):010:0> URI::Parser.new.escape(name)
=> "Test%20File%20With%20Spaces.csv"
```