### PR TITLE
Add support for ruby 3.2.2+

### DIFF
--- a/sharepoint-ruby.gemspec
+++ b/sharepoint-ruby.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.license      = '0BSD'
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'curb', '~> 0.8', '<= 0.9.11'
+  s.add_runtime_dependency 'curb'
 end


### PR DESCRIPTION
Curb 0.9.11 is not compatible with ruby 3.2.2+, removing this will allow the use of this gem on latest ruby versions.